### PR TITLE
Pull Request - Documentation Updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -170,7 +170,7 @@ markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 
 
 # Conversion
-markdown: CommonMarkGhPages
+markdown: kramdown
 highlighter: rouge
 lsi: false
 excerpt_separator: "\n\n"

--- a/_config.yml
+++ b/_config.yml
@@ -170,7 +170,7 @@ markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 
 
 # Conversion
-markdown: kramdown
+markdown: CommonMarkGhPages
 highlighter: rouge
 lsi: false
 excerpt_separator: "\n\n"

--- a/_config.yml
+++ b/_config.yml
@@ -170,7 +170,7 @@ markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 
 
 # Conversion
-markdown: kramdown
+markdown: GFM
 highlighter: rouge
 lsi: false
 excerpt_separator: "\n\n"

--- a/_config.yml
+++ b/_config.yml
@@ -179,7 +179,7 @@ incremental: false
 
 # Markdown Processing
 kramdown:
-  input: GFM
+  input: GFM # This must be GFM - Kramdown will break the collapsible menus, CommonMarkGH will break the table formatting.
   hard_wrap: false
   auto_ids: true
   footnote_nr: 1

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,15 +1,15 @@
 # main links
 main:
   - title: "About"
-    url: https://adus.github.io/portal-documentation/about/
+    url: /about/
   - title: "Documentation"
-    url: https://adus.github.io/portal-documentation/documents/
+    url: /documents/
   - title: "Updates"
-    url: https://adus.github.io/portal-documentation/updates-notices/
+    url: /updates-notices/
   - title: "PUG"
-    url: https://adus.github.io/portal-documentation/documents_pug/
+    url: /documents_pug/
   - title: "Uses"
-    url: https://adus.github.io/portal-documentation/uses-of-portal/
+    url: /uses-of-portal/
   - title: "PORTAL"
     url: http://portal.its.pdx.edu/
   # - title: "Sitemap"
@@ -29,6 +29,8 @@ documents:
         url: /documents/travel-time/
       - title: "Abbreviations"
         url: /documents/abbreviations/
+      - title: "API Access Examples"
+        url: /documents/access_examples/
       - title: "Data Sources"
         url: /documents/datasources/
       - title: "Definitions"

--- a/_documents/abbreviations.md
+++ b/_documents/abbreviations.md
@@ -5,6 +5,7 @@ title: "Abbreviations"
 |---|---|
 | ADUS | Archived Data User Service |
 | APC | Automatic Passenger County |
+| ATSPM | Automated Traffic Signal Performance |
 | AVL | Automatic Vehicle Location |
 | DriveNET |
 | FHWA | Federal Highway Administration |
@@ -14,6 +15,10 @@ title: "Abbreviations"
 | ODOT | Oregon Department of Transportation |
 | PSU | Portland State University |
 | RITIS | Regional Integrated Transportation Information System |
+| TOCS | Transporation Operations Center System |
+| TREC | Transporation Research and Education Center |
+| VAS | Variable Advisory Speed |
+| VMS | Variable Message System |
 | VHT | Vehicle Hours Traveled |
 | VMT | Vehicle Miles Traveled |
 | VPLPH | Vehicles per Lane per Hour |

--- a/_documents/abbreviations.md
+++ b/_documents/abbreviations.md
@@ -7,7 +7,7 @@ title: "Abbreviations"
 | APC | Automatic Passenger County |
 | ATSPM | Automated Traffic Signal Performance |
 | AVL | Automatic Vehicle Location |
-| DriveNET |
+| DriveNET | Digital Roadway Interactive Visualization and Evaluation Network |
 | FHWA | Federal Highway Administration |
 | iPeMS |Iteris Performance Management System |
 | ITS | Intelligent Transportation Systems |
@@ -22,3 +22,4 @@ title: "Abbreviations"
 | VHT | Vehicle Hours Traveled |
 | VMT | Vehicle Miles Traveled |
 | VPLPH | Vehicles per Lane per Hour |
+| WSDOT | Washington State Department of Transportation |

--- a/_documents/abbreviations.md
+++ b/_documents/abbreviations.md
@@ -23,3 +23,5 @@ title: "Abbreviations"
 | VMT | Vehicle Miles Traveled |
 | VPLPH | Vehicles per Lane per Hour |
 | WSDOT | Washington State Department of Transportation |
+
+Last Updated: 2020-07-07

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -11,6 +11,7 @@ By the end of the tutorial users should be able to:
 
 <details><summary>Sample cURL Requests</summary>
 <p>
+
 The versatility of cURL makes it straightforward to download PORTAL data from the command line. However, each form on the Downloads page, e.g. Highways, Detector Metadata, Aggregated TravelTime Data, etc., has a unique combination of fields to be filled.  Some basic access examples to facilitate easier cURL access will be provided below.
 
 #### Curl Example \#1 - Highways Data, Single Day

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -9,7 +9,7 @@ By the end of the tutorial users should be able to:
 
 * Understand how to access the API using cURL and Python
 
-<details><summary>cURL Request examples</summary>
+<details><summary>Sample cURL Requests</summary>
 <p>
 The versatility of cURL makes it straightforward to download PORTAL data from the command line. However, each form on the Downloads page, e.g. Highways, Detector Metadata, Aggregated TravelTime Data, etc., has a unique combination of fields to be filled.  Some basic access examples to facilitate easier cURL access will be provided below.
 
@@ -51,14 +51,14 @@ This query on the TriMet ridership dataset returns the TriMet for the selected q
 </p>
 </details>
 
-<details><summary>Python Request examples</summary>
+<details><summary>Sample Python Requests</summary>
 <p>
 Python methods will go here.
 </p>
 </details>
 
-<details><summary>Query-Specific Fields</summary>
+<details><summary>Query Specific Tables</summary>
 <p>
-This section will be a list tables of values specific to each query - ie, a list of highways by Hwy # in the Highways dataset, to facilitate ease of use.
+This section will be a list of tables of values specific to each query - i.e., a list of highways by Hwy # in the Highways dataset, to facilitate ease of use.
 </p>
 </details>

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -54,12 +54,14 @@ This query on the TriMet ridership dataset returns the TriMet for the selected q
 
 <details><summary>Sample Python Requests</summary>
 <p>
+  
 Python methods will go here.
 </p>
 </details>
 
 <details><summary>Query Specific Tables</summary>
 <p>
+  
 This section will be a list of tables of values specific to each query - i.e., a list of highways by Hwy # in the Highways dataset, to facilitate ease of use.
 </p>
 </details>

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -1,0 +1,22 @@
+---
+title: "API Access Examples"
+---
+The _API Access Examples_ page offers some insight into accessing the API using various common methods. What follows here is a simple
+code repository which provides a basic framework for how to interface with the API.
+
+## Learning objectives
+By the end of the tutorial users should be able to:
+
+* Understand how to access the API using cURL and Python
+
+<details><summary>cURL Request examples</summary>
+<p>
+cURL methods will go here.
+</p>
+</details>
+
+<details><summary>Python Request examples</summary>
+<p>
+Python methods will go here.
+</p>
+</details>

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -11,7 +11,43 @@ By the end of the tutorial users should be able to:
 
 <details><summary>cURL Request examples</summary>
 <p>
-cURL methods will go here.
+The versatility of cURL makes it straightforward to download PORTAL data from the command line. However, each form on the Downloads page, e.g. Highways, Detector Metadata, Aggregated TravelTime Data, etc., has a unique combination of fields to be filled.  Some basic access examples to facilitate easier cURL access will be provided below.
+
+#### Curl Example \#1 - Highways Data, Single Day
+```
+curl 'http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/?start_date=2020-05-11&end_date=2020-05-11&format=
+csv&highway_id=3&highway_id=54&resolution=00%3A15%3A00' -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer:
+http://new.portal.its.pdx.edu:8080/downloads/ -o highways_data.csv'
+```
+
+This sample query on the Highways dataset returns CSV formatted data with a 15 minute resolution for the highways with ID values 3 and 54 (I-205 NB, and I-205 NB Washington) for May 11, 2020.  It then saves that data into a csv file using -o.
+
+#### Curl Example \#2 - Highways Data, Limited by Days of Week Over a Range of Dates
+```
+curl "http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/?start_date=2020-05-04&end_date=2020-05-15&
+days_of_week=1&days_of_week=2&days_of_week=3&days_of_week=4&days_of_week=5&days_of_week=6&days_of_week=7&format=csv&
+highway_id=3&highway_id=54&resolution=01"%"3A00"%"3A00" -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer: 
+http://new.portal.its.pdx.edu:8080/downloads/ -o highways_data.csv'
+```
+
+This sample query on the Highways dataset returns CSV formatted data with a 15 minute resolution for the highways with ID values 3 and 51 (I-205 NB and I-205 NB Washington) for Wednesdays, Thursdays and Fridays only, within a date range of May 05, 2020 and May 15, 2020.
+
+#### Curl Example \#3 - Travel Time Data
+```
+curl "http://new.portal.its.pdx.edu:8080/traveltime/api/aggregatedsegmentcalcs/?start_date=2020-05-27
+&end_date=2020-0527&format=csv&resolution=01"%"3A00"%"3A00&segment_id=2264&segment_id=2275" -H 'Host:
+new.portal.its.pdx.edu:8080' -H 'Referer: http://new.portal.its.pdx.edu:8080/downloads/ -o travel_time_data.csv'
+```
+
+This sample query on the Travel Time dataset returns CSV formatted data with a 1 hour resolution, for the I-205 Foster NB and SB segments. 
+
+#### Curl Example \#4 - Trimet Data
+```
+curl "http://new.portal.its.pdx.edu:8080/transit/downloadquarterlydata?agency=trimet&quarter=2019-q3-summer"
+-H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer: http://new.portal.its.pdx.edu:8080/downloads/ -o trimet_data.zip'
+```
+
+This query on the TriMet ridership dataset returns the TriMet for the selected quarter; zip is selected here as that is how the file is served through the website - when unzipped, the data is available in .csv format _only_.
 </p>
 </details>
 

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -44,7 +44,7 @@ This sample query on the Travel Time dataset returns CSV formatted data with a 1
 #### Curl Example \#4 - Trimet Data
 ```
 curl "http://new.portal.its.pdx.edu:8080/transit/downloadquarterlydata?agency=trimet&quarter=2019-q3-summer"
--H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer: http://new.portal.its.pdx.edu:8080/downloads/ -o trimet_data.zip'
+-H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer: http://new.portal.its.pdx.edu:8080/downloads/ -o trimet.zip'
 ```
 
 This query on the TriMet ridership dataset returns the TriMet for the selected quarter; zip is selected here as that is how the file is served through the website - when unzipped, the data is available in .csv format _only_.

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -14,60 +14,196 @@ Each of the forms on the downloads page has a set of fields which may be filled 
 
 The date format used by the forms is YYYY-MM-DD.
 
-<details><summary>Sample cURL Requests</summary>  The values for some of these fields, such as the highway_id or segment_id fields in the Highways Data and Travel Time Data forms respectively, are available through the Highways Metadata or Travel Time Metadata forms. 
-<p>
+<details><summary>Sample cURL Requests</summary>
 
-The versatility of cURL makes it straightforward to download PORTAL data from the command line.  Some basic access examples to facilitate easier cURL access will be provided below.
+<p>
+The versatility of cURL makes it straightforward to download PORTAL data from the command line.  Some basic access examples to facilitate easier cURL access are provided below.
 
 #### Curl Example \#1 - Highways Data, Single Day
+
+The following sample query on the Highways dataset returns CSV formatted data with a 15 minute resolution for the highways with ID values 3 and 54 (I-205 NB, and I-205 NB Washington) for May 11, 2020.  It then saves that data into a csv file using -o.
+
 ```
 curl 'http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/?start_date=2020-05-11&end_date=2020-05-11&
 format=csv&highway_id=3&highway_id=54&resolution=00%3A15%3A00' -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer:
 http://new.portal.its.pdx.edu:8080/downloads/ -o highways_data.csv'
 ```
 
-This sample query on the Highways dataset returns CSV formatted data with a 15 minute resolution for the highways with ID values 3 and 54 (I-205 NB, and I-205 NB Washington) for May 11, 2020.  It then saves that data into a csv file using -o.
-
 #### Curl Example \#2 - Highways Data, Limited by Days of Week Over a Range of Dates
-```
-curl "http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/?start_date=2020-05-04&end_date=2020-05-15&
-days_of_week=1&days_of_week=2&days_of_week=3&days_of_week=4&days_of_week=5&days_of_week=6&days_of_week=7&format
-=csv&highway_id=3&highway_id=54&resolution=01"%"3A00"%"3A00" -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer: 
-http://new.portal.its.pdx.edu:8080/downloads/ -o highways_data.csv'
-```
 
-This sample query on the Highways dataset returns CSV formatted data with a 15 minute resolution for the highways with ID values 3 and 51 (I-205 NB and I-205 NB Washington) for Wednesdays, Thursdays and Fridays only, within a date range of May 05, 2020 and May 15, 2020.
+The following sample query on the Highways dataset returns CSV formatted data with a 15 minute resolution for the highways with ID values 3 and 51 (I-205 NB and I-205 NB Washington) for Wednesdays, Thursdays and Fridays only, within a date range of May 05, 2020 and May 15, 2020.
+
+```
+curl "http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/?start_date=2020-05-04&end_date=2020-05-15&days_of_
+week=3&days_of_week=4&days_of_week=5&format=csv&highway_id=3&highway_id=54&resolution=01"%"3A00"%"3A00" -H 'Host:
+new.portal.its.pdx.edu:8080' -H 'Referer: http://new.portal.its.pdx.edu:8080/downloads/ -o highways_data.csv'
+```
 
 #### Curl Example \#3 - Travel Time Data
+
+The following sample query on the Travel Time dataset returns CSV formatted data with a 1 hour resolution, for the I-205 Foster NB and SB segments.
+
 ```
 curl "http://new.portal.its.pdx.edu:8080/traveltime/api/aggregatedsegmentcalcs/?start_date=2020-05-27
-&end_date=2020-0527&format=csv&resolution=01"%"3A00"%"3A00&segment_id=2264&segment_id=2275" -H 'Host:
+&end_date=2020-05-27&format=csv&resolution=01"%"3A00"%"3A00&segment_id=2264&segment_id=2275" -H 'Host:
 new.portal.its.pdx.edu:8080' -H 'Referer: http://new.portal.its.pdx.edu:8080/downloads/ -o travel_time_data.csv'
 ```
 
-This sample query on the Travel Time dataset returns CSV formatted data with a 1 hour resolution, for the I-205 Foster NB and SB segments. 
-
 #### Curl Example \#4 - Trimet Data
+
+The following query on the TriMet ridership dataset returns the TriMet for the selected quarter; zip is selected here as that is how the file is served through the website - when unzipped, the data is available in .csv format _only_.
+
 ```
 curl "http://new.portal.its.pdx.edu:8080/transit/downloadquarterlydata?agency=trimet&quarter=2019-q3-summer"
 -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer: http://new.portal.its.pdx.edu:8080/downloads/ -o trimet.zip'
 ```
 
-This query on the TriMet ridership dataset returns the TriMet for the selected quarter; zip is selected here as that is how the file is served through the website - when unzipped, the data is available in .csv format _only_.
 </p>
 </details>
 
 <details><summary>Sample Python Requests</summary>
 <p>
   
-Python methods will go here.
+#### The following Python examples will work verbatim in Python 3.6 or later. Earlier versions will require some modification.
+
+#### Python Example \#1 - Highways Data, Single Day
+
+The following sample query on the Highways dataset returns CSV formatted data with a 15 minute resolution for the highways with ID values 3 and 54 (I-205 NB, and I-205 NB Washington) for May 11, 2020.  It then saves that data into a csv file using -o.
+
+```
+import requests
+import csv
+
+headers = {
+        'Host': 'new.portal.its.pdx.edu:8080',
+        'Referer': 'http://new.portal.its.pdx.edu:8080/downloads/',
+}
+
+params = (
+        ('start_date', '2020-05-11'),
+        ('end_date', '2020-05-11'),
+        ('format', 'csv'),
+        ('highway_id', ['3', '54']),
+        ('resolution', '00:15:00'),
+)
+try:
+    response = requests.get('http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/',
+            headers = headers, params = params)
+    response.raise_for_status()
+except HTTPError as http_err:
+    print(f'HTTP Error: {http_err}')
+except Exception as err:
+    print(f'Error: {err}')
+else:
+    print('Writing Output.')
+
+with open('highways_data.csv', 'w+') as file:
+    file.write(response.text)
+```
+
+#### Python Example \#2 - Highways Data, Limited by Days of Week Over a Range of Dates
+
+The following sample query on the Highways dataset returns CSV formatted data with a 15 minute resolution for the highways with ID values 3 and 51 (I-205 NB and I-205 NB Washington) for Wednesdays, Thursdays and Fridays only, within a date range of May 05, 2020 and May 15, 2020.
+
+```
+import requests
+import csv
+
+headers = {
+        'Host': 'new.portal.its.pdx.edu:8080',
+        'Referer': 'http://new.portal.its.pdx.edu:8080/downloads/',
+}
+
+params = (
+        ('start_date', '2020-05-04'),
+        ('end_date', '2020-05-15'),
+        ('days_of_week',['3', '4', '5']),
+        ('format', 'csv'),
+        ('highway_id', ['3', '54']),
+        ('resolution', '01:00:00'),
+)
+
+try:
+    response = requests.get('http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/',
+        headers=headers, params=params)
+    response.raise_for_status()
+except HTTPError as http_err:
+    print(f'HTTP Error: {http_err}')
+except Exception as err:
+    print(f'Error: {err}')
+else:
+    print('Writing Output.')
+
+with open('highways_data.csv', 'w+') as file:
+    file.write(response.text)
+```
+
+#### Python Example \#3 - Travel Time Data
+
+The following sample query on the Travel Time dataset returns CSV formatted data with a 1 hour resolution, for the I-205 Foster NB and SB segments. 
+
+```
+import requests
+import csv
+
+headers = {
+        'Host': 'new.portal.its.pdx.edu:8080',
+        'Referer': 'http://new.portal.its.pdx.edu:8080/downloads/',
+}
+
+params = (
+        ('start_date', '2020-05-27'),
+        ('end_date', '2020-05-27'),
+        ('format', 'csv'),
+        ('resolution', '01:00:00'),
+        ('setgment_id', ['2264', '2275']),
+)
+
+try:
+    response = requests.get('http://new.portal.its.pdx.edu:8080/traveltime/api/aggregatedsegmentcalcs/',
+            headers=headers, params=params)
+    response.raise_for_status()
+except HTTPError as http_err:
+    print(f'HTTP error occurred: {http_err}')
+except Exception as err:
+    print(f'Other error occurred: {err}')
+else:
+    print('Writing Output')
+
+with open('travel_time_data.csv', 'w+') as file:
+    file.write(response.text)
+```
+
+#### Curl Example \#4 - Trimet Data
+
+The following query on the TriMet ridership dataset returns the TriMet for the selected quarter; zip is selected here as that is how the file is served through the website - when unzipped, the data is available in .csv format _only_.
+
+```
+import requests
+
+headers = {
+        'Referer': 'http://new.portal.its.pdx.edu:8080/downloads/',
+}
+
+params = (
+        ('agency', 'trimet'),
+        ('quarter', '2019-q3-summer'),
+)
+
+try:
+    response = requests.get('http://new.portal.its.pdx.edu:8080/transit/downloadquarterlydata',
+            headers = headers, params=params)
+    response.raise_for_status()
+except HttpError as http_err:
+    print(f'HTTP Error: {http_err}')
+except Exception as err:
+    print(f'Error: {err}')
+else:
+    print('Downloading Zip File.')
+with open('transit_data.zip', 'wb') as zipfile:
+    for chunk in response.iter_content(128):
+        zipfile.write(chunk)
+```
+
 </p>
 </details>
-
-<details><summary>Query Specific Tables</summary>
-<p>
-  
-This section will be a list of tables of values specific to each query - i.e., a list of highways by Hwy # in the Highways dataset, to facilitate ease of use.
-</p>
-</details>
-

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -207,3 +207,4 @@ with open('transit_data.zip', 'wb') as zipfile:
 
 </p>
 </details>
+Last Updated: 2020-07-07

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -7,17 +7,22 @@ code repository which provides a basic framework for how to interface with the A
 ## Learning objectives
 By the end of the tutorial users should be able to:
 
-* Understand how to access the API using cURL and Python
+* Understand how to fill the fields involved in making a request to the database.
+* Understand how to access the API using cURL and Python.
 
-<details><summary>Sample cURL Requests</summary>
+Each of the forms on the downloads page has a set of fields which may be filled in order to request a constrained set of data. The purpose of some of these fields, such as start_date and end_date should be self-explanatory.  The individual values for other, less-intuitive fields, such as the station_id, highway_id or segment_id fields are available through the Stations Metadata, Highways Metadata, or Travel Time Segment Inventory forms, all of which only require start and end dates as input.
+
+The date format used by the forms is YYYY-MM-DD.
+
+<details><summary>Sample cURL Requests</summary>  The values for some of these fields, such as the highway_id or segment_id fields in the Highways Data and Travel Time Data forms respectively, are available through the Highways Metadata or Travel Time Metadata forms. 
 <p>
 
-The versatility of cURL makes it straightforward to download PORTAL data from the command line. However, each form on the Downloads page, e.g. Highways, Detector Metadata, Aggregated TravelTime Data, etc., has a unique combination of fields to be filled.  Some basic access examples to facilitate easier cURL access will be provided below.
+The versatility of cURL makes it straightforward to download PORTAL data from the command line.  Some basic access examples to facilitate easier cURL access will be provided below.
 
 #### Curl Example \#1 - Highways Data, Single Day
 ```
-curl 'http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/?start_date=2020-05-11&end_date=2020-05-11&format=
-csv&highway_id=3&highway_id=54&resolution=00%3A15%3A00' -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer:
+curl 'http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/?start_date=2020-05-11&end_date=2020-05-11&
+format=csv&highway_id=3&highway_id=54&resolution=00%3A15%3A00' -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer:
 http://new.portal.its.pdx.edu:8080/downloads/ -o highways_data.csv'
 ```
 
@@ -26,8 +31,8 @@ This sample query on the Highways dataset returns CSV formatted data with a 15 m
 #### Curl Example \#2 - Highways Data, Limited by Days of Week Over a Range of Dates
 ```
 curl "http://new.portal.its.pdx.edu:8080/highways/api/freewaydata/?start_date=2020-05-04&end_date=2020-05-15&
-days_of_week=1&days_of_week=2&days_of_week=3&days_of_week=4&days_of_week=5&days_of_week=6&days_of_week=7&format=csv&
-highway_id=3&highway_id=54&resolution=01"%"3A00"%"3A00" -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer: 
+days_of_week=1&days_of_week=2&days_of_week=3&days_of_week=4&days_of_week=5&days_of_week=6&days_of_week=7&format
+=csv&highway_id=3&highway_id=54&resolution=01"%"3A00"%"3A00" -H 'Host: new.portal.its.pdx.edu:8080' -H 'Referer: 
 http://new.portal.its.pdx.edu:8080/downloads/ -o highways_data.csv'
 ```
 

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -56,3 +56,9 @@ This query on the TriMet ridership dataset returns the TriMet for the selected q
 Python methods will go here.
 </p>
 </details>
+
+<details><summary>Query-Specific Fields</summary>
+<p>
+This section will be a list tables of values specific to each query - ie, a list of highways by Hwy # in the Highways dataset, to facilitate ease of use.
+</p>
+</details>

--- a/_documents/access_examples.md
+++ b/_documents/access_examples.md
@@ -65,3 +65,4 @@ Python methods will go here.
 This section will be a list of tables of values specific to each query - i.e., a list of highways by Hwy # in the Highways dataset, to facilitate ease of use.
 </p>
 </details>
+

--- a/_documents/datasources.md
+++ b/_documents/datasources.md
@@ -2,7 +2,7 @@
 title: "Data Sources"
 ---
 
-The primary data sources used in Portal are the following:
+The following primary data sources are used by Portal:
 
 | Source | Data | Agency | Resolution | Notes |
 | :----- | :--- | :----- | :--------- | :---- |
@@ -21,3 +21,5 @@ The following data sources may be added in the future:
 | Source | Data | Agency |
 | :----- | :--- | :----- |
 | Arterial | ATSPM | City of Portland |
+
+Last Updated: 2020-07-07

--- a/_documents/datasources.md
+++ b/_documents/datasources.md
@@ -2,6 +2,22 @@
 title: "Data Sources"
 ---
 
-A description of the primary data sources available in PORTAL.
+The primary data sources used in Portal are the following:
 
-Link here: [Data Sources]({{ site.url }}{{ site.baseurl }}/assets/pdfs/PORTAL_DataSources_20200402.pdf)
+| Source | Data | Agency | Resolution | Notes |
+| :----- | :--- | :----- | :--------- | :---- |
+| Freeway | Speed, volume, occupancy, VMT, VHT, travel time, delay | ODOT | 20 sec, 5 min, 15 min, 1 hour, 1 day | Data used and available on Travel Time, Highways, Stations, and Downloads pages in Portal. Ramp data is also included. |
+| Freeway | TOCS Incident Data | ODOT | N/A | Data available upon request. |
+| Freeway | VMS, VAS | ODOT | 1 min | Data Available upon request. |
+| Vehicle Length | Volume per vehicle length bin | ODOT | 15 min, 1 hour, 1 day | Data used and available on Vehicle Length and Downloads pages in PORTAL |
+| Travel Time | Travel time, reliability, sample count | City of Portland, ODOT, Washington County | 20 sec, 5 min, 15 min, 1 hour, 1 day | Data used and available on Travel Time and Downloads pages in Portal |
+| Transit | Quarterly Cleaned Ridership, On-Time Performance | TriMet | Quarterly | Data available on Downloads page |
+| Arterial | Traffic Signal Data, Including System Detector Counts (TransCore Data) | City of Portland | 5 min, 15 min, 1 hour, 1 day | Data available on Arterial Page |
+| Arterial | Bike Counts | City of Portland | 5 min, 15 min, 1 hour, 1 day | Data available on Arterial page. |
+| Weather | Wind Speed, Temperature, Humidity, Precipitation, Visibility | NOAA | 1 hour | Data available on Stations page. |
+
+The following data sources may be added in the future:
+
+| Source | Data | Agency |
+| :----- | :--- | :----- |
+| Arterial | ATSPM | City of Portland |

--- a/_documents/downloads.md
+++ b/_documents/downloads.md
@@ -141,15 +141,24 @@ The following data are provided:
 
 ### Aggregated CLS
 The following data are provided:
-- aggregated_records: 
+- aggregated_records: Number of records sampled to create individual data point.
 - bin_count: Count of vehicles by classification bin.
-- bin_type: Description of classification bin as seen in the _following table_.
-- bin_number: Classification bin number - classifications by length may be seen in the _following table_.
+- bin_type: Description of classification bin - either length or speed.
+- bin_number: Classification bin number.  These classifications can be seen in the table below this section.
 - bin_resolution: Temporal Resolution - 15 minutes, one hour, or one day.
 - bin_time: The timestamp of the data value, to a granularity of 20 seconds.
-- id: 
+- id: The record id value used by the API framework (Django).
 - lane: Lane in which the data was collected. Lane 1 is the left most lane.
 - stationid: Unique id of the collection station, which corresponds to the agencyid in the stations metadata.
+
+Bin Number Classifications:
+
+|Bin Number | Vehicle Length |
+|-----------|----------------|
+|        1  |      0-20 ft.  |
+|        2  |     20-35 ft.  |
+|        3  |     35-60 ft.  |
+|        4  |    60-120 ft.  |
 
 More information about Vehicle Length data can be seen [_here._]({{ site.url }}{{ site.baseurl }}/documents/freight/)
 

--- a/_documents/downloads.md
+++ b/_documents/downloads.md
@@ -141,17 +141,17 @@ The following data are provided:
 
 ### Aggregated CLS
 The following data are provided:
-- aggregated_records:
-- bin_count:
-- bin_number:
+- aggregated_records: 
+- bin_count: Count of vehicles by classification bin.
+- bin_type: Description of classification bin as seen in the _following table_.
+- bin_number: Classification bin number - classifications by length may be seen in the _following table_.
 - bin_resolution: Temporal Resolution - 15 minutes, one hour, or one day.
-- bin_time:
-- bin_type:
-- id:
-- lane: Lane 1 is the left most lane.
-- stationid: Unique station id, which corresponds to the agencyid in the stations metadata.
+- bin_time: The timestamp of the data value, to a granularity of 20 seconds.
+- id: 
+- lane: Lane in which the data was collected. Lane 1 is the left most lane.
+- stationid: Unique id of the collection station, which corresponds to the agencyid in the stations metadata.
 
-To [_Vehicle Lengths_]({{ site.url }}{{ site.baseurl }}/documents/freight/)
+More information about Vehicle Length data can be seen [_here._]({{ site.url }}{{ site.baseurl }}/documents/freight/)
 
 ### Voyage Volume
 

--- a/_documents/downloads.md
+++ b/_documents/downloads.md
@@ -1,7 +1,7 @@
 ---
 title: "Downloads"
 ---
-In addition to being able to download data from each page in PORTAL, the _Downloads_ page provides the opportunity to download data over longer time frames over multiple locations.
+In addition to being able to download data from each page in PORTAL, the _Downloads_ page provides the opportunity to download data over longer time frames, multiple locations, or both.
 
 ## Learning objectives
 By the end of the tutorial users should be able to:
@@ -9,69 +9,80 @@ By the end of the tutorial users should be able to:
 * Understand the parameters of each download option for each section
 * Know what data is being downloaded (e.g. variables and units)
 
+<details><summary>Highways Data</summary>
+<p>
+
 ### Highways
 Highway data can be downloaded from this section by selecting the start and end date of interest, days of week, format, highway of interest, and temporal resolution. Multiple highway sections can be downloaded by holding the ctrl key and clicking on the desired highway.
 
 The following data are provided:
-- starttime: start time
-- resolution: temporal resolution of frequency of data collected
-- detector_id: detector id along selected route
-- speed: average speed of vehicles traveling per hour that pass the detector
-- volume: number of vehicles per hour that pass the detector
-- occupancy: percent of time cars are being detected
+- starttime: Start time of the data.
+- resolution: Temporal resolution of frequency of data.
+- detector_id: Detector id along selected route.
+- speed: Average speed of vehicles traveling per hour that pass the detector.
+- volume: Number of vehicles per hour that pass the detector.
+- occupancy: Percentage of time cars are being detected.
 - countreadings:
-- delay: vht minus the time it would take a vehicle to travel at the maximum permitted speed on a segment.
-- traveltime: the average amount of time spent traveling within a segment.
-- vht: (vehicle hours traveled) total hours traveled within a segment by - all vehicles
-- vmt: (vehicle miles traveled) total miles traveled on a segment by all vehicles
+- delay: VHT minus the time it would take a vehicle to travel at the maximum permitted speed on a segment.
+- traveltime: The average amount of time for vehicles to travel through a segment.
+- vht: (vehicle hours traveled) Total hours traveled within a segment by all vehicles.
+- vmt: (vehicle miles traveled) Total miles traveled on a segment by all vehicles.
 
-To get distance traveled divide vmt by volume.
+Distance traveled can be calculated by dividing vmt by volume.
 
-### [Stations metadata]
+A tutorial on using the Highways function can be found [_here_]({{ site.url }}{{ site.baseurl }}/documents/highways/).
+
+### Stations metadata
 
 The following data are provided:
-- stationid: station ID
-- highwayid: highway ID
-- milepost: milepost (mi)
-- locationtext: agency provided location information
-- length: length of segment (mi)
-- numberlanes: number of lanes at the station
-- agencyid: ID of the agency maintaining the station
-- x_coord: longitude
-- y_coord: latitude
-- active_dates: active date of station
+- stationid: Station ID.
+- highwayid: Highway ID.
+- milepost: Milepost (mi).
+- locationtext: Agency provided location information.
+- length: Length of segment in miles.
+- numberlanes: Number of lanes at the station.
+- agencyid: ID of the agency maintaining the station.
+- x_coord: Longitude of station.
+- y_coord: Latitude.
+- active_dates: Initial active date of station.
 
-To [_Stations_]({{ site.url }}{{ site.baseurl }}/documents/stations/)
+An interactive map of all the stations in the network can be viewed [_here_]({{ site.url }}{{ site.baseurl }}/documents/stations/)
 
 ### Detector metadata
 
 The following data are provided:
-- detectorid: unique detector id, used to join with raw or aggregated data
-- stationid: unique station id, used to join with stations metadata
-- highwayid: unique highway id, used to join with highways metadata
-- milepost: milepost (mi)
-- detectortitle: agency given name or id for detector
-- lanenumber: PORTAL lane number, where lane 1 is the left most lane regardless of agency jurisdiction
-- agency_lane: agency given lane number where lane 1 is left most lane for ODOT, and lane 1 is right most lane for WSDOT
-- active_dates: active date of detector
+- detectorid: Unique detector id, used to join with raw or aggregated data.
+- stationid: Unique station id, used to join with stations metadata.
+- highwayid: Unique highway id, used to join with highways metadata.
+- milepost: Milepost (mi).
+- detectortitle: Agency given name or id for detector.
+- lanenumber: PORTAL lane number, where lane 1 is the left most lane regardless of agency jurisdiction.
+- agency_lane: Agency given lane number where lane 1 is left most lane for ODOT, and lane 1 is right most lane for WSDOT.
+- active_dates: Initial active date of detector.
 
-To [_Stations_]({{ site.url }}{{ site.baseurl }}/documents/stations/)
+An interactive map of all the stations in the network can be viewed here [_here_]({{ site.url }}{{ site.baseurl }}/documents/stations/)
 
 ### Highways metadata
 The following data are provided:
-- highwayid: unique highway id
-- direction: direction of flow
-- highwayname: name of highway
-- oppositehighwayid: id of highway of opposite flow
+- highwayid: Unique highway id.
+- direction: Direction of flow.
+- highwayname: Name of highway.
+- oppositehighwayid: Id of highway with opposite flow.
+
+</p>
+</details>
+
+<details><summary>Travel Time Data</summary>
+<p>
 
 ### Aggregated travel time
 The following data are provided:
-- average_travel_time: average travel time of segment (min)
-- countreadings: sample size
+- average_travel_time: Average travel time of segment in minutes.
+- countreadings: Sample size.
 - id:
-- resolution: either one hour or five minutes
-- segment_id: unique id, used to join with travel time segment inventory metadata
-- starttime: start time of chosen resolution
+- resolution: Temporal resolution of data - either one hour or five minutes.
+- segment_id: Unique id, used to join with travel time segment inventory metadata.
+- starttime: Start time of chosen resolution.
 
 ### Raw travel time
 The following data are provided:
@@ -108,34 +119,46 @@ The following data are provided:
 
 ### Travel time DCU inventory
 The following data are provided:
-- active: true or false
-- dcu_id:
-- dcu_name:
-- geom.coordinates.0: longitude
-- geom.cooridnates.1: latitude
-- geom.type:
-- highway: highway name
-- latitude: latitude
-- location_type: intersection or free flowing traffic
-- longitude: longitude
-- milepoint:
-- owner: agency name
+- active: True or False.
+- dcu_id: Unique id value; preceded by ```-``` if location_type is free flowing traffic.
+- dcu_name: Name of intersection, if location_type is Intersection. Eg. Foster Rd at SE 82nd.\
+            Numeric, matching dcu_id value without leading ```-``` if location type is free flowing traffic.
+- geom.type: This data field is always "Point", for geom.coordinates.
+- geom.coordinates.0: Longitude
+- geom.coordinates.1: Latitude.
+- highway: Highway Name.
+- latitude: Latitude.
+- location_type: Intersection or free flowing traffic, dependant on location.
+- longitude: Longitude.
+- milepoint: Null for free flowing traffic.  Float value for intersections.
+- owner: Agency name.
 - roadway_number:
+</p>
+</details>
+
+<details><summary>Other Download Categories</summary>
+<p>
 
 ### Aggregated CLS
 The following data are provided:
 - aggregated_records:
 - bin_count:
 - bin_number:
-- bin_resolution: 15 minutes, one hour, one day
+- bin_resolution: Temporal Resolution - 15 minutes, one hour, or one day.
 - bin_time:
 - bin_type:
 - id:
-- lane: lane 1 is the left most lane
-- stationid: unique station id, to be used with stations metadata
+- lane: Lane 1 is the left most lane.
+- stationid: Unique station id, which corresponds to the agencyid in the stations metadata.
 
 To [_Vehicle Lengths_]({{ site.url }}{{ site.baseurl }}/documents/freight/)
 
 ### Voyage Volume
 
-Last updated: 2019-10-31
+### Transit Quarterly Data
+</p>
+</details>
+
+
+
+Last updated: 2020-04-29

--- a/_documents/downloads.md
+++ b/_documents/downloads.md
@@ -170,4 +170,4 @@ More information about Vehicle Length data can be seen [_here._]({{ site.url }}{
 
 
 
-Last updated: 2020-04-29
+Last updated: 2020-07-07

--- a/_documents/freight.md
+++ b/_documents/freight.md
@@ -51,29 +51,6 @@ The "Aggregate" plot option will prompt two additional selection criteria, "Meas
   <figcaption>Figure 3. Screen shot of the <i>Vehicle Length</i> page showing the "Aggregated" selection criteria and plot for vehicle length. The plot shows the total vehicle counts for all the Saturdays and Sundays in the month of 2018-04 for all vehicles in the ranges of (20, 35] and (35, 60] ft over a 24 hour period. </figcaption>
 </figure>
 
-#### Vehicle speed
-The "Standard" option will show the daily vehicle speeds binned by 10 mph increments from (0, 10] to (90, 100] mph. Once plotted, each speed range can be turned on and off by clicking on the desired legend key.
-
-#### _Example_
-<figure class="align-left">
-  <img src="{{ site.url }}{{ site.baseurl }}/assets/images/vehicle-length-img4" alt = "">
-  <figcaption>Figure 4. Screen shot of the <i>Vehicle Length</i> page showing the "Standard" selection criteria and plot for vehicle speed. The plot shows the total vehicle counts for all speed ranges at 15 minute resolution. To examine data over a finer time scale, a selection is made by clicking and dragging across the plot to highlight 2018-04-05 through 2018-04-08.</figcaption>
-</figure>
-
-#### _Example_
-<figure class="align-left">
-  <img src="{{ site.url }}{{ site.baseurl }}/assets/images/vehicle-length-img5" alt = "">
-  <figcaption>Figure 5. Screen shot of the <i>Vehicle Length</i> page showing the "Standard" selection criteria and plot for vehicle speed after zooming in to the selected time frame of 2018-04-05 through 2018-04-08. The resent button in the upper right corner will zoom out to the original plot.</figcaption>
-</figure>  
-
-
-The "Aggregate" plot option will prompt two additional selection criteria, "Measure Ranges", and "Week Days". "Measure Ranges" provides the option of aggregating the selected ranges. "Week Days" provides the option of selecting which days of the week should be aggregated. The start and end date will default to the month and year of the initial start and end date. The resulting plot will show the total vehicle count of the selected aggregated options over a 24-hour period for an entire month. The default selection is all days of the week and all vehicle speed ranges.
-
-#### _Example_
-<figure class="align-left">
-  <img src="{{ site.url }}{{ site.baseurl }}/assets/images/vehicle-length-img6" alt = "">
-  <figcaption>Figure 6. Screen shot of the <i>Vehicle Length</i> page showing the "Aggregated" selection criteria and plot of vehicle speeds for 2018-04 with (0, 10] and (80, 100] unselected, and Friday and Saturday selected, over a 24 hour period.</figcaption>
-</figure>  
 
 ### Step 6: Download data
 Click on the "Download" button to download data used to generate each type of plot.

--- a/_documents/freight.md
+++ b/_documents/freight.md
@@ -32,7 +32,7 @@ Select the time resolution of interest by using the drop down menu under "Resolu
 
 ### Step 5: Select type of plot
 
-Once a type of plot is selected (description on the types below) then click on the "Update" button to render the plot. Once the plot is rendered, users have the option to zoom in by clicking and dragging the cursor the length of the desired time frame.
+Once a type of plot is selected (description on the types below) then click on the "Update" button to render the plot. Once the plot is rendered, users have the option to zoom in by clicking and dragging the cursor the length of the desired time frame.  It is recommended to use the "Standard" plot option, for daily vehicle length count.
 
 #### Vehicle length
 The "Standard" plot option will show daily vehicle length count based on four distinct binned lengths (0, 20] ft, (20, 30] ft, (35, 60] ft, and (60, 120] ft. The plotted vehicle length ranges can be turned on and off by clicking on the individual legend keys. Individual point values will appear in a pop-up window by moving the cursor to the desired point.
@@ -97,4 +97,4 @@ Table 1: Class names and descriptions from MAG Internal Truck Travel Survey and 
   <figcaption>Figure 7. Potential set of length bins.</figcaption>
 </figure>
 
-Last updated: 2019-12-12
+Last updated: 2020-07-07


### PR DESCRIPTION
All of the documentation changes I have made to date, ready for review.

- Changed markdown type to Kramdown in order to better support Github Pages / tables
- Reduced length of URLs in navigation.yml, so that this can be hosted by documentation editor on an offsite Github Pages acct at any future time, as well as on the main adus.github.io page.
- Added initial pass of API examples page.
- Added numerous Abbreviations to abbreviations page.
- Added Data Sources directly to table in datasources page, rather than linking through to a pdf.
- Changed or clarified most attributes listed on downloads page.  Some work remains to be done there.
- Removed speed references from freight page.